### PR TITLE
Support for style query in url

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Append any emoji to the end of `emojicdn.elk.sh` to get a PNG image:
 <img src="https://emojicdn.elk.sh/🥳" />
 ```
 
-## `style`
+## Emoji style
 
 For more control, add the `style` query parameter to specify an emoji platform: 
 

--- a/README.md
+++ b/README.md
@@ -1,0 +1,36 @@
+# EMOJICDN
+
+## Basic usage
+
+Append any emoji to the end of `emojicdn.elk.sh` to get a PNG image:
+
+```
+<img src="https://emojicdn.elk.sh/🥳" />
+```
+
+## `style`
+
+For more control, add the `style` query parameter to specify an emoji platform: 
+
+```
+<img src="https://emojicdn.elk.sh/🥳?style=google" />
+```
+
+If no `style` is provided, the API defaults to `apple`. 
+
+Supported styles: 
+
+* `apple`
+* `google`
+* `microsoft`
+* `samsung`
+* `whatsapp`
+* `twitter`
+* `facebook`
+* `joypixels`
+* `openmoji`
+* `emojidex`
+* `messenger`
+* `lg`
+* `htc`
+* `mozilla`

--- a/api/image.js
+++ b/api/image.js
@@ -20,17 +20,17 @@ module.exports = async (req, res) => {
   ]
 
   const send404Error = error => {
-    res.status(404).send(`${error}`)
+    res.status(404).send(error)
   }
 
   const send400Error = error => {
-    res.status(400).send(`${error}`)
+    res.status(400).send(error)
   }
 
   if (!style) style = "apple"
-  const re = new RegExp(`<img.*src="(\\S.*?${style.toLowerCase()}\\S.*?)"`, 'g'); // find style within url link
   if (!allowedStyles.includes(style.toLowerCase()))
     return send400Error("Invalid style.")
+  const re = new RegExp(`<img.*src="(\\S.*?${style.toLowerCase()}\\S.*?)"`, 'g'); // find style within img src url
 
   const request = await fetch(`https://emojipedia.org/${encodeURIComponent(emoji)}`)
   if (!request.ok)
@@ -39,7 +39,7 @@ module.exports = async (req, res) => {
   const text = await request.text()
   const urlArray = text.match(re)
   if (!urlArray)
-    return send404Error("Style for emoji not found")
+    return send404Error("Style not found for this emoji.")
   const url = urlArray[0].replace(/<img src=/g, "").replace(/"/g, "")
   const image = await fetch(url)
 

--- a/api/image.js
+++ b/api/image.js
@@ -30,7 +30,7 @@ module.exports = async (req, res) => {
   if (!style) style = "apple"
   if (!allowedStyles.includes(style.toLowerCase()))
     return send400Error("Invalid style.")
-  const re = new RegExp(`<img.*src="(\\S.*?${style.toLowerCase()}\\S.*?)"`, 'g'); // find style within img src url
+  const re = new RegExp(`<img.*src.*="(\\S.*?${style.toLowerCase()}\\S.*?)"`, "g"); // find style within img src/srcset url
 
   const request = await fetch(`https://emojipedia.org/${encodeURIComponent(emoji)}`)
   if (!request.ok)
@@ -40,7 +40,8 @@ module.exports = async (req, res) => {
   const urlArray = text.match(re)
   if (!urlArray)
     return send404Error("Style not found for this emoji.")
-  const url = urlArray[0].replace(/<img src=/g, "").replace(/"/g, "")
+  const url = urlArray[0].match(/src.*?="(.*?)"/g).reverse()[0].replace(/src.*=/g, "").replace(/"/g, "").replace(" 2x", "")
+    // take the last src/srcset url, since that's the highest quality
   const image = await fetch(url)
 
   res.setHeader("content-type", "image/png")

--- a/api/image.js
+++ b/api/image.js
@@ -20,10 +20,12 @@ module.exports = async (req, res) => {
   ]
 
   const send404Error = error => {
+    res.setHeader("content-type", "text/plain")
     res.status(404).send(error)
   }
 
   const send400Error = error => {
+    res.setHeader("content-type", "text/plain")
     res.status(400).send(error)
   }
 

--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
   <head>
     <title>EMOJICDN</title>
     <link rel="icon" href="/🥳">
-    <meta name="description" content="An API for getting PNG images of Apple emojis.">
+    <meta name="description" content="An API for getting PNG images of emojis.">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link rel="stylesheet" href="https://rsms.me/inter/inter.css">
 
@@ -96,13 +96,20 @@
         font: inherit;
         text-decoration-color: var(--underline);
       }
+
+      code {
+        color: inherit;
+        font-family: "SFMono-Regular", Menlo, monospace;
+        font-weight: 600;
+        font-size: inherit;
+      }
     </style>
   </head>
 
   <body>
     <main>
       <p class="logo">EMOJICDN</p>
-      <h1>Get PNG images of Apple emojis.</h1>
+      <h1>Get PNG images of emojis.</h1>
 
       <div class="chips">
         <p>Free</p>
@@ -112,15 +119,15 @@
 
       <div class="instructions">
         <p>
-          Just append the emoji you want to this URL. For example: <a href="https://emojicdn.elk.sh/🥳">emojicdn.elk.sh/🥳</a>.
+          Just append the emoji you want to this URL. For example: <a href="/🥳">emojicdn.elk.sh/🥳</a>.
         </p>
 
         <p>
-          You can directly use that URL as an image.
+          Add a <code>?style=</code> query parameter to choose which platform (Apple, Google, Twitter, etc.) to get the emoji from - more details in the <a href="https://github.com/benborgers/emojicdn">README</a>.
         </p>
 
         <p>
-          This API comes in handy for favicons, or for using Apple's emojis across platforms (since their artwork looks the nicest), etc. 
+          This API comes in handy for favicons, using emojis across platforms, and for user-generated content.
         </p>
 
         <p>


### PR DESCRIPTION
Support for selecting emoji style with a query string.
e.g. emojicdn.elk.sh/🥳?style=twitter

Adds more error handling.

Defaults to the Apple style if no style included in the URL, to allow existing applications that only use emoji query to work.